### PR TITLE
Update ImagePickerModule.java

### DIFF
--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -353,7 +353,7 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
     else
     {
       requestCode = REQUEST_LAUNCH_IMAGE_LIBRARY;
-      libraryIntent = new Intent(Intent.ACTION_PICK,
+      libraryIntent = new Intent(Intent.ACTION_OPEN_DOCUMENT,
       MediaStore.Images.Media.EXTERNAL_CONTENT_URI);
 
       if (pickBoth) 


### PR DESCRIPTION
I propose that inside ImagePicker.java we use "libraryIntent = new Intent(Intent.ACTION_OPEN_DOCUMENT" instead of "libraryIntent = new Intent(Intent.ACTION_PICK" for the following reasons:

As of Android M, certain permissions are temporary to the activity that was running at the point when that permission was granted by the client. 

see: https://stackoverflow.com/questions/37024668/issue-react-native-android-provider-permission-denial-exception

see: https://stackoverflow.com/questions/30572261/using-data-from-context-providers-or-requesting-google-photos-read-permission

In the case of React Native Image Picker on Android, this is fine for once-off accessing and making use of an image that a client selects from Google Photos or any other photo library. I ran into an issue when a user accesses an image and I store the uri to that image on device. In this case, while the uri is saved on device and the user closes and reopens the app, an error will be throw on Android pertaining to denied permissions to the photos provider since the activity that originally requested the permission is no longer running.

By making use of "ACTION_OPEN_DOCUMENT", the uri permissions to the image is persisted across activities therefor the error is not raised

Thanks for submitting a PR! Please read these instructions carefully:

- [ ] Explain the **motivation** for making this change.
- [ ] Provide a **test plan** demonstrating that the code is solid.
- [ ] Match the **code formatting** of the rest of the codebase.
- [ ] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

What existing problem does the pull request solve?

## Test Plan (required)

A good test plan has the exact commands you ran and their output, provides screenshots or videos if the pull request changes UI or updates the website. See [What is a Test Plan?][1] to learn more.  

If you have added code that should be tested, add tests.

[1]: https://medium.com/@martinkonicek/what-is-a-test-plan-8bfc840ec171#.y9lcuqqi9
